### PR TITLE
fix boostrapping issues

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -304,7 +304,8 @@ function run_passes(ci::CodeInfo, sv::OptimizationState)
     ir = compact!(ir)
     svdef = sv.linfo.def
     nargs = isa(svdef, Method) ? Int(svdef.nargs) : 0
-    state = find_escapes!(ir, nargs+1, sv)
+    state = find_escapes!(ir, nargs+1)
+    EscapeAnalysis.GLOBAL_ESCAPE_CACHE[sv.linfo] = state
     #@Base.show ("before_sroa", ir)
     @timeit "SROA" ir = getfield_elim_pass!(ir)
     #@Base.show ir.new_nodes

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -27,6 +27,9 @@ function _all(@nospecialize(f), a)
     return true
 end
 
+all(itr) = all(identity, itr)
+all(f, itr) = _all(f, itr)
+
 function contains_is(itr, @nospecialize(x))
     for y in itr
         if y === x


### PR DESCRIPTION
This succeeds in bootsrapping. But I found there are still some issues around the global cache that should appear during sysimage creation, which might stem from the same problem as https://github.com/aviatesk/EscapeAnalysis.jl/issues/48.
